### PR TITLE
Fix GTK 4.22+ launch crash from idle-deferred autoconnect

### DIFF
--- a/src/common/hexchat.c
+++ b/src/common/hexchat.c
@@ -813,13 +813,6 @@ sigusr2_handler (int signal, siginfo_t *si, void *un)
 }
 #endif
 
-static gint
-xchat_auto_connect (gpointer userdata)
-{
-	servlist_auto_connect (NULL);
-	return 0;
-}
-
 void
 xchat_init (void)
 {
@@ -991,7 +984,12 @@ xchat_init (void)
 				new_ircwindow (NULL, NULL, SESS_SERVER, 0);
 		} else
 		{
-			fe_idle_add (xchat_auto_connect, NULL);
+			/* Run autoconnect synchronously so at least one
+			 * GtkApplicationWindow exists when the GtkApplication's
+			 * activate signal returns; deferring via g_idle_add let
+			 * GApplication's use_count hit zero in GTK 4.22+, which
+			 * unregistered the app before the idle dispatched. */
+			servlist_auto_connect (NULL);
 		}
 	} else
 	{


### PR DESCRIPTION
## Summary

- HexChat fails to launch under `G_DEBUG=fatal-criticals` on GTK 4.22+ for users with `hex_gui_slist_skip` + auto-connect servers, dying with `Gtk-CRITICAL: New application windows must be added after the GApplication::startup signal has been emitted.`
- Root cause: `xchat_init` schedules `servlist_auto_connect` via `fe_idle_add` — a legacy pattern from the `gtk_main()` era. Under `g_application_run`, the idle now fires inside the main loop. If no `GtkApplicationWindow` is added synchronously during `activate`, `GApplication`'s `use_count` hits zero, the app unregisters, and the later window add hits the registration check.
- Fix: call `servlist_auto_connect` directly so the first window exists while `activate` is still on the stack. Removes the now-unused `xchat_auto_connect` wrapper.

The other three branches of `xchat_init` already create a window synchronously (`fe_serverlist_open`, or `new_ircwindow SESS_SERVER`); the autoconnect path was the only one that deferred.

## Test Plan

- [x] Without the fix on GTK 4.22.1 (macOS, Homebrew): `env G_DEBUG=fatal-criticals ./hexchat` crashes on launch with the registration critical.
- [x] With the fix: `./hexchat` launches and reaches the main window with auto-connect running normally.
- [x] Full meson test suite (9 suites, 200+ subtests) passes.